### PR TITLE
As per Bluetooth core specification, bluetooth adapter should exit loop

### DIFF
--- a/README
+++ b/README
@@ -49,3 +49,9 @@ You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2
 
 
 
+
+
+
+
+
+


### PR DESCRIPTION
back mode on hci reset. Add HCI quirk reset to make sure adapter exits
loopback mode on bluetooth socket closure.

Tracked-On: OAM-102732
Signed-off-by: Suresh, Prashanth prashanth.suresh@intel.com